### PR TITLE
20191001_breadcrumb

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem 'ancestry'
 gem 'payjp'
 gem 'omniauth-facebook'
 gem 'omniauth-google-oauth2'
+gem 'gretel'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,8 @@ GEM
       romaji
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    gretel (3.0.9)
+      rails (>= 3.1.0)
     haml (5.1.1)
       temple (>= 0.8.0)
       tilt
@@ -334,6 +336,7 @@ DEPENDENCIES
   faker
   font-awesome-rails
   gimei
+  gretel
   haml-rails
   jbuilder (~> 2.5)
   jquery-rails

--- a/app/views/categories/index.html.haml
+++ b/app/views/categories/index.html.haml
@@ -1,4 +1,6 @@
 = render "shared/header"
+- breadcrumb :categories
+= breadcrumbs pretext: "",separator: " &rsaquo; ", class: "breadcrumbs-list"
 .categoryHeader
   %h2 カテゴリー一覧
   .header_content

--- a/app/views/categories/search.html.haml
+++ b/app/views/categories/search.html.haml
@@ -1,4 +1,6 @@
 = render "shared/header"
+- breadcrumb :category_search
+= breadcrumbs pretext: "",separator: " &rsaquo; ", class: "breadcrumbs-list"
 .searchCategory
   - if @items.present?
     = render partial: 'items/item', collection: @items

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -26,7 +26,7 @@
       - if user_signed_in?
         %ul.listsRight
           %li.listsRight__item
-            = link_to user_path(current_user.id) do
+            = link_to user_path(id: current_user.id, name: 'マイページ') do
               = image_tag("member_photo_noimage_thumb.png", size: "32x32",)
               %span マイページ
           %li.listsRight__item

--- a/app/views/users/_leftcontent.html.haml
+++ b/app/views/users/_leftcontent.html.haml
@@ -1,7 +1,7 @@
 .leftContent
   %ul
     %li
-      = link_to user_path(current_user) do
+      = link_to user_path(id: current_user.id, name: 'マイページ') do
         %span マイページ
         = fa_icon "angle-right"
     %li
@@ -9,31 +9,31 @@
         %span お知らせ
         = fa_icon "angle-right"
     %li
-      = link_to likes_user_path(current_user) do
+      = link_to likes_user_path(id: current_user.id, name: 'いいね！一覧') do
         %span いいね！一覧
         = fa_icon "angle-right"
     %li
-      = link_to new_item_path do
+      = link_to new_item_path(id: current_user.id, name: '出品する') do
         %span 出品する
         = fa_icon "angle-right"
     %li
-      = link_to listings_user_path(current_user) do
+      = link_to listings_user_path(id: current_user.id, name: '出品した商品---出品中') do
         %span 出品した商品---出品中
         = fa_icon "angle-right"
     %li
-      = link_to in_progress_user_path(current_user) do
+      = link_to in_progress_user_path(id: current_user.id, name: '出品した商品---取引中') do
         %span 出品した商品---取引中
         = fa_icon "angle-right"
     %li
-      = link_to completed_user_path(current_user) do
+      = link_to completed_user_path(id: current_user.id, name: '出品した商品---売却済') do
         %span 出品した商品---売却済
         = fa_icon "angle-right"
     %li
-      = link_to purchase_user_path(current_user) do
+      = link_to purchase_user_path(id: current_user.id, name: '購入した商品---取引中') do
         %span 購入した商品---取引中
         = fa_icon "angle-right"
     %li
-      = link_to purchased_user_path(current_user) do
+      = link_to purchased_user_path(id: current_user.id, name: '購入した商品---過去の取引') do
         %span 購入した商品---過去の取引
         = fa_icon "angle-right"
     %li

--- a/app/views/users/completed.html.haml
+++ b/app/views/users/completed.html.haml
@@ -1,16 +1,6 @@
 = render "shared/header"
-%nav.breadCrumbs
-  %ul
-    %li
-      = link_to "メルカリ", root_path
-    %li
-      = fa_icon "angle-right"
-    %li
-      = link_to " マイページ", user_path(current_user)
-    %li
-      = fa_icon "angle-right"
-    %li
-      %p 出品した商品 - 売却済み
+- breadcrumb :mypage
+= breadcrumbs separator: " &rsaquo; "
 .main
   .contents
     = render "leftcontent"

--- a/app/views/users/in_progress.html.haml
+++ b/app/views/users/in_progress.html.haml
@@ -1,16 +1,6 @@
 = render "shared/header"
-%nav.breadCrumbs
-  %ul
-    %li
-      = link_to "メルカリ", root_path
-    %li
-      = fa_icon "angle-right"
-    %li
-      = link_to " マイページ", user_path(current_user)
-    %li
-      = fa_icon "angle-right"
-    %li
-      %p 出品した商品 - 取引中
+- breadcrumb :mypage
+= breadcrumbs separator: " &rsaquo; "
 .main
   .contents
     = render "leftcontent"

--- a/app/views/users/listings.html.haml
+++ b/app/views/users/listings.html.haml
@@ -1,16 +1,6 @@
 = render "shared/header"
-%nav.breadCrumbs
-  %ul
-    %li
-      = link_to "メルカリ", root_path
-    %li
-      = fa_icon "angle-right"
-    %li
-      = link_to " マイページ", user_path(current_user)
-    %li
-      = fa_icon "angle-right"
-    %li
-      %p 出品した商品 - 出品中
+- breadcrumb :mypage
+= breadcrumbs separator: " &rsaquo; "
 .main
   .contents
     = render "leftcontent"

--- a/app/views/users/purchase.html.haml
+++ b/app/views/users/purchase.html.haml
@@ -1,16 +1,6 @@
 = render "shared/header"
-%nav.breadCrumbs
-  %ul
-    %li
-      = link_to "メルカリ", root_path
-    %li
-      = fa_icon "angle-right"
-    %li
-      = link_to " マイページ", user_path(current_user)
-    %li
-      = fa_icon "angle-right"
-    %li
-      %p 購入した商品 - 取引中
+- breadcrumb :mypage
+= breadcrumbs separator: " &rsaquo; "
 .main
   .contents
     = render "leftcontent"

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,12 +1,6 @@
 = render "shared/header"
-%nav.breadCrumbs
-  %ul
-    %li
-      = link_to "メルカリ", root_path
-    %li
-      = fa_icon "angle-right"
-    %li
-      %p マイページ
+- breadcrumb :mypage
+= breadcrumbs separator: " &rsaquo; "
 .main
   .contents
     = render "leftcontent"

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,0 +1,22 @@
+crumb :root do
+  link "メルカリ", root_path
+end
+
+# category index
+crumb :categories do
+  link "カテゴリー一覧", categories_path
+  parent :root
+end
+
+crumb :category_search do
+  category = Category.find(params[:id])
+  link "#{category.name}", search_category_path(category)
+  parent :categories
+end
+
+crumb :mypage do
+  user = User.find(params[:id])
+  name = params[:name]
+  link "#{name}", user_path(user)
+  parent :root
+end


### PR DESCRIPTION
# what
パンくず機能の実装
# why
ユーザーがページ遷移した時に今自分がどの履歴でこのページにいるのかを把握できるようにするため。